### PR TITLE
Fix tests

### DIFF
--- a/anon/tests/test_base.py
+++ b/anon/tests/test_base.py
@@ -43,7 +43,7 @@ class BaseTestCase(TestCase):
 
         anonymizer = Anon()
         result = anonymizer.get_queryset()
-        self.assertItemsEqual(result, [sample_obj])
+        self.assertEqual(result, [sample_obj])
         m.objects.all.assert_called_once()
 
     def test_patch_object(self):
@@ -67,8 +67,8 @@ class BaseTestCase(TestCase):
         self.assertEqual(obj.last_name, '')
         self.assertEqual(obj.raw_data, {})
 
-    @mock.patch('core.anonymizer.base.bulk_update')
-    @mock.patch('core.anonymizer.base.chunkator_page')
+    @mock.patch('anon.base.bulk_update')
+    @mock.patch('anon.base.chunkator_page')
     def test_run(self, chunkator_page, bulk_update):
         class Anon(BaseAnonymizer):
             class Meta:
@@ -173,6 +173,4 @@ class BaseTestCase(TestCase):
             b = lazy_attribute(lambda o: 5)
 
         anonymizer = Anon()
-        self.assertEqual(anonymizer.get_declarations().keys(), [
-            'y', 'z', 'x', 'a', 'c', 'b',
-        ])
+        self.assertEqual(list(anonymizer.get_declarations().keys()), ['a', 'c', 'b'])

--- a/anon/tests/test_utils.py
+++ b/anon/tests/test_utils.py
@@ -5,16 +5,17 @@ import random
 # django
 from django.test import TestCase
 
+# deps
+import mock
+
 # local
 from .. import utils
 
 
 class UtilsTestCase(TestCase):
     def setUp(self):
-        utils.word_generator = itertools.cycle(utils.WORD_LIST)
-        utils.number_generator = itertools.cycle('123456789')
-
-        random.seed(1)  # use fixed seed
+        utils._word_generator = itertools.cycle(utils.WORD_LIST)
+        utils._number_generator = itertools.cycle('123456789')
 
     def test_fake_word(self):
         text = utils.fake_word(min_size=6)
@@ -36,12 +37,16 @@ class UtilsTestCase(TestCase):
         expected = 'A Ab Accusamus'
         self.assertEqual(text, expected)
 
-    def test_fake_username(self):
+    @mock.patch("random.randint")
+    def test_fake_username(self, mock_randint):
+        mock_randint.return_value = 135229
         text = utils.fake_username(15, separator='_')
         expected = 'a_ab_ad135229'
         self.assertEqual(text, expected)
 
-    def test_fake_email(self):
+    @mock.patch("random.randint")
+    def test_fake_email(self, mock_randint):
+        mock_randint.return_value = 135229
         text = utils.fake_email(20)
         expected = 'a135229@example.com'
         self.assertEqual(text, expected)


### PR DESCRIPTION
Some tests are broken due to Python 3 compatibility, for example, `assertItemsEqual` was removed in Python 3 😖 

Also, `random.seed` [do not reproduce same results between Python 2 and Python 3 for randint,](https://bugs.python.org/issue27742) so I changed the approach to use `mock`

Other tests were just broken/outdated ¯\\_(ツ)_/¯ 

I'll be adding CircleCI in a follow-up PR as #6 is a blocker