### PR TITLE
Move raw directive out of README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,37 +1,4 @@
-
-
-.. raw:: html
-
-    <p align="center">
-      <a href="https://github.com/Tesorio/django-anon">
-        <img src="https://raw.githubusercontent.com/Tesorio/django-anon/master/icon.svg?sanitize=true" width="128">
-      </a>
-    </p>
-
-    <h1 align="center">django-anon</h1>
-    <p align="center">
-      <strong>
-        <img src="https://github.githubassets.com/images/icons/emoji/shipit.png" width="16"> Anonymize production data so it can be safely used in not-so-safe environments
-      </strong>
-    </p>
-
-    <p align="center">
-      <a href="https://circleci.com/gh/Tesorio/django-anon">
-        <img src="https://circleci.com/gh/Tesorio/django-anon.svg?style=svg&circle-token=373da2a214669014ef040e5a06a7f1a974902daa">
-      </a>
-      <a href="https://django-anon.readthedocs.io/en/latest/">
-        <img src="https://readthedocs.org/projects/pip/badge/?version=latest&style=flat">
-      </a>
-      <a href="https://github.com/Tesorio/django-anon/blob/master/LICENSE.txt">
-        <img src="https://img.shields.io/badge/license-MIT-blue.svg">
-      </a>
-    </p>
-    
-    <p align="center">
-      <a href="https://django-anon.readthedocs.io/en/latest/">
-        Read Documentation
-      </a>
-    </p>
+.. include:: README_banner.rst
 
 **django-anon** will help you anonymize your production database so it can be
 shared among developers, helping to reproduce bugs and make performance improvements

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+
+
 .. raw:: html
 
     <p align="center">

--- a/README_banner.rst
+++ b/README_banner.rst
@@ -1,0 +1,32 @@
+.. raw:: html
+
+    <p align="center">
+      <a href="https://github.com/Tesorio/django-anon">
+        <img src="https://raw.githubusercontent.com/Tesorio/django-anon/master/icon.svg?sanitize=true" width="128">
+      </a>
+    </p>
+
+    <h1 align="center">django-anon</h1>
+    <p align="center">
+      <strong>
+        <img src="https://github.githubassets.com/images/icons/emoji/shipit.png" width="16"> Anonymize production data so it can be safely used in not-so-safe environments
+      </strong>
+    </p>
+
+    <p align="center">
+      <a href="https://circleci.com/gh/Tesorio/django-anon">
+        <img src="https://circleci.com/gh/Tesorio/django-anon.svg?style=svg&circle-token=373da2a214669014ef040e5a06a7f1a974902daa">
+      </a>
+      <a href="https://django-anon.readthedocs.io/en/latest/">
+        <img src="https://readthedocs.org/projects/pip/badge/?version=latest&style=flat">
+      </a>
+      <a href="https://github.com/Tesorio/django-anon/blob/master/LICENSE.txt">
+        <img src="https://img.shields.io/badge/license-MIT-blue.svg">
+      </a>
+    </p>
+    
+    <p align="center">
+      <a href="https://django-anon.readthedocs.io/en/latest/">
+        Read Documentation
+      </a>
+    </p>


### PR DESCRIPTION
Since PyPI does not support the raw directive, moving it to another file so we can wipe it out before sending to PyPI as a description