### PR TITLE
Fix -- hide HTML banner on PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,8 +42,6 @@
 shared among developers, helping to reproduce bugs and make performance improvements
 in a production-like environment.
 
-----
-
 .. image:: https://raw.githubusercontent.com/Tesorio/django-anon/master/django-anon-recording.gif
 
 Features

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. BANNER
+.. BANNERSTART
 .. Since PyPI does not support raw directives, we remove them from the README
 ..
 .. raw directives are only used to make README fancier on GitHub and do not

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,9 @@
+.. BANNER
+.. Since PyPI does not support raw directives, we remove them from the README
+..
+.. raw directives are only used to make README fancier on GitHub and do not
+.. contain relevant information to be displayed in PyPI, as they are not tied
+.. to the current version, but to the current development status
 .. raw:: html
 
     <p align="center">
@@ -30,10 +36,13 @@
         Read Documentation
       </a>
     </p>
+.. BANNEREND
 
 **django-anon** will help you anonymize your production database so it can be
 shared among developers, helping to reproduce bugs and make performance improvements
 in a production-like environment.
+
+----
 
 .. image:: https://raw.githubusercontent.com/Tesorio/django-anon/master/django-anon-recording.gif
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,25 @@ VERSION = __import__("anon").__version__
 
 
 with open("README.rst") as readme_file:
-    README = readme_file.read()
+
+    def remove_banner(readme):
+        # Since PyPI does not support raw directives, we remove them from the README
+        #
+        # raw directives are only used to make README fancier on GitHub and do not
+        # contain relevant information to be displayed in PyPI, as they are not tied
+        # to the current version, but to the current development status
+        out = []
+        lines = iter(readme.splitlines(keepends=True))
+        for line in lines:
+            if line.startswith(".. BANNER"):
+                for line in lines:
+                    if line.strip() == ".. BANNEREND":
+                        break
+            else:
+                out.append(line)
+        return "".join(out)
+
+    README = remove_banner(readme_file.read())
 
 
 class PublishCommand(Command):
@@ -49,6 +67,7 @@ setup(
     # metadata for upload to PyPI
     description="Anonymize production data so it can be safely used in not-so-safe environments",
     long_description=README,
+    long_description_content_type="text/x-rst",
     author="Tesorio",
     author_email="hello@tesorio.com",
     url="https://github.com/Tesorio/django-anon",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("README.rst") as readme_file:
         # contain relevant information to be displayed in PyPI, as they are not tied
         # to the current version, but to the current development status
         out = []
-        lines = iter(readme.splitlines(keepends=True))
+        lines = iter(readme.splitlines(True))
         for line in lines:
             if line.startswith(".. BANNER"):
                 for line in lines:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("README.rst") as readme_file:
         out = []
         lines = iter(readme.splitlines(True))
         for line in lines:
-            if line.startswith(".. BANNER"):
+            if line.startswith(".. BANNERSTART"):
                 for line in lines:
                     if line.strip() == ".. BANNEREND":
                         break


### PR DESCRIPTION
<!-- Note: Before submitting this pull request, please review our [contributing guidelines](https://github.com/Tesorio/django-anon/blob/master/CONTRIBUTING.md#pull-requests) -->

## Description

PyPI does not allow rendering `.. raw:: ` reStructuredText directives. Since they are only used to make Github page fancier and may also cause confusion with badges on master vs version that is stable, I've just omitted it from README

I've been using https://packaging.python.org/guides/using-testpypi/ to test