### PR TITLE
Improve performance of fake_username

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,3 +28,5 @@ master
 * Added test for Django 3 using Python 3.7 in tox.ini
 * Improved performance of fake_text
 * Improved performance of BaseAnonymizer.patch_object
+* Improved performance of fake_username
+* Removed range_range argument from fake_username (backwards incompatible)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,4 +29,4 @@ master
 * Improved performance of fake_text
 * Improved performance of BaseAnonymizer.patch_object
 * Improved performance of fake_username
-* Removed range_range argument from fake_username (backwards incompatible)
+* Removed rand_range argument from fake_username (backwards incompatible)

--- a/README.rst
+++ b/README.rst
@@ -119,7 +119,7 @@ Built-in functions
    fake_text(max_size=255, max_diff_allowed=5, separator=' ')
    fake_small_text(max_size=50)
    fake_name(max_size=15)
-   fake_username(max_size=10, separator='', rand_range=(1000, 999999))
+   fake_username(max_size=10, separator='')
    fake_email(max_size=25, suffix='@example.com')
    fake_url(max_size=50, scheme='http://', suffix='.com')
    fake_phone_number(format='999-999-9999')

--- a/anon/utils.py
+++ b/anon/utils.py
@@ -188,19 +188,45 @@ _WORD_LIST = [
     "voluptatum",
 ]
 
-# The _avg_word_size holds the average size of word sample
+
+try:
+    xrange
+except NameError:
+    # Python 2/3 proof
+    xrange = range
+
+
+def _cycle_over_sample_range(start, end, sample_size):
+    """
+    Given a range (start, end), returns a generator that will cycle over a population
+    sample with size specified by ``sample_size``
+    """
+    return itertools.cycle(random.sample(xrange(start, end), sample_size))
+
+
+# Holds the average size of word sample
 _avg_word_size = sum(map(len, _WORD_LIST)) / len(_WORD_LIST)
 
-# The _word_generator holds a generator that each iteration returns a
-# different word
+# Holds a generator that each iteration returns a different word
 _word_generator = itertools.cycle(_WORD_LIST)
 
 # Holds the size of smallest word in _WORD_LIST and is used to define bounds
 _min_word_size = len(sorted(_WORD_LIST, key=lambda w: len(w))[0])
 
-# The number_generatator holds a generator that each iteration returns a
-# different number
+# Holds a generator that each iteration returns a different number
 _number_generator = itertools.cycle("86306894249026785203141")
+
+# Holds a generator for small integers, same as Django's PositiveSmallIntegerField
+_small_int_generator = _cycle_over_sample_range(0, 32767, 1000)
+
+# Holds a generator for small signed integers, same as Django's SmallIntegerField
+_small_signed_int_generator = _cycle_over_sample_range(-32768, 32767, 1000)
+
+# Holds a generator for integers, same as Django's PositiveIntegerField
+_int_generator = _cycle_over_sample_range(0, 2147483647, 10000)
+
+# Holds a generator for signed integers, same as Django's IntegerField
+_signed_int_generator = _cycle_over_sample_range(-2147483648, 2147483647, 100000)
 
 
 def fake_word(min_size=_min_word_size, max_size=20):
@@ -257,7 +283,7 @@ def fake_name(max_size=15):
     return fake_text(max_size=max_size).title()
 
 
-def fake_username(max_size=10, separator="", rand_range=(1000, 999999)):
+def fake_username(max_size=10, separator=""):
     """ Returns fake username
 
     :max_size: Maximum number of chars
@@ -265,13 +291,7 @@ def fake_username(max_size=10, separator="", rand_range=(1000, 999999)):
     :rand_range: Range to use when generating random number
 
     """
-    rand_start, rand_end = rand_range
-    if not rand_end > rand_start:
-        raise ValueError(
-            "rand_range start ({}) must be > end ({})".format(rand_start, rand_end)
-        )
-
-    random_number = str(random.randint(rand_start, rand_end))
+    random_number = str(next(_small_int_generator))
     min_size_allowed = _min_word_size + len(random_number)
 
     if max_size < min_size_allowed:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,6 +28,7 @@ class UtilsTestCase(TestCase):
     def test_fake_username(self):
         text = utils.fake_username(45, separator="_")
         self.assertIn("_", text)
+        self.assertLessEqual(len(text), 45)
 
     def test_fake_email(self):
         text = utils.fake_email(20)


### PR DESCRIPTION
<!--
Note: Before submitting this pull request, please review our [contributing guidelines](https://github.com/Tesorio/django-anon/blob/master/CONTRIBUTING.md#pull-requests)
-->

## Description

**This PR introduces a backwards-incompatible change** by removing the `rand_range` argument from `fake_username`. With our focus being on performance, getting rid of expensive calls, such as `random`, is essential. The same/old behavior can still be accomplished using  a custom function.

The impact of this change, being backwards-incompatible, is still minimal since as mentioned above the same behavior can still be accomplished using a custom function, and, the `rand_range` argument was optional.

## Profiling results

**Before changes**

```python
Total time: 35.0136 s
File: anon/utils.py
Function: fake_username at line 260

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   260                                           @profile
   261                                           def fake_username(max_size=10, separator="", rand_range=(1000, 999999)):
   262                                               """ Returns fake username
   263
   264                                               :max_size: Maximum number of chars
   265                                               :separator: Word separator
   266                                               :rand_range: Range to use when generating random number
   267
   268                                               """
   269   1000000    1481137.0      1.5      4.2      rand_start, rand_end = rand_range
   270   1000000    1197990.0      1.2      3.4      if not rand_end > rand_start:
   271                                                   raise ValueError(
   272                                                       "rand_range start ({}) must be > end ({})".format(rand_start, rand_end)
   273                                                   )
   274
   275   1000000   18277722.0     18.3     52.2      random_number = str(random.randint(rand_start, rand_end))
   276   1000000    1983915.0      2.0      5.7      min_size_allowed = _min_word_size + len(random_number)
   277
   278   1000000    1242765.0      1.2      3.5      if max_size < min_size_allowed:
   279                                                   raise ValueError("username must be >= {}".format(min_size_allowed))
   280                                               else:
   281   1000000    1369452.0      1.4      3.9          max_size -= len(random_number)
   282
   283   1000000    9460604.0      9.5     27.0      return fake_text(max_size, separator=separator) + random_number
```

**After changes**

```python
Total time: 15.1933 s (2.3 times faster)
File: anon/utils.py
Function: fake_username at line 290

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   290                                           @profile
   291                                           def fake_username(max_size=10, separator=""):
   292                                               """ Returns fake username
   293
   294                                               :max_size: Maximum number of chars
   295                                               :separator: Word separator
   296                                               :rand_range: Range to use when generating random number
   297
   298                                               """
   299   1000000    2576025.0      2.6     17.0      random_number = str(next(_small_int_generator))
   300   1000000    2003946.0      2.0     13.2      min_size_allowed = _min_word_size + len(random_number)
   301
   302   1000000    1035719.0      1.0      6.8      if max_size < min_size_allowed:
   303                                                   raise ValueError("username must be >= {}".format(min_size_allowed))
   304                                               else:
   305   1000000    1324213.0      1.3      8.7          max_size -= len(random_number)
   306
   307   1000000    8253427.0      8.3     54.3      return fake_text(max_size, separator=separator) + random_number
```

<!--
Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Todos

- [ ] Tests
- [x] Documentation
- [x] Changelog
