### PR TITLE
Fix -- Add .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,20 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .


### PR DESCRIPTION
Problem:
--------

Currently documentation is not showing code snippets in the API
Reference section. Looking at the build logs, there is these warnings:

> WARNING: autodoc: failed to import function 'fake_word' from module
> 'anon'; the following exception was raised:
> No module named 'chunkator'

ReadTheDocs does not performs `pip install .` by default, which means
that when trying to `import anon` it will fail due to dependencies not
being installed.

**See:** https://django-anon.readthedocs.io/en/latest/reference.html

Solution
--------

Add the recommended `.readthedocs.yml` configuration file as it allows
specifying ReadTheDocs to run `pip install .`, which will install
dependencies and let code snippets to be processed and appear in the
documentation

**Documentation built with this branch:**
https://django-anon.readthedocs.io/en/fix-51882c/reference.html

<!--
Note: Before submitting this pull request, please review our [contributing guidelines](https://github.com/Tesorio/django-anon/blob/master/CONTRIBUTING.md#pull-requests)
-->

## Description

<!--
Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog
