### PR TITLE
Fix CI failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v1.1.1
+      - uses: actions/setup-python@v1
       - uses: actions/checkout@v1
 
       - run: pip install coverage


### PR DESCRIPTION
<!--
Note: Before submitting this pull request, please review our [contributing guidelines](https://github.com/Tesorio/django-anon/blob/master/CONTRIBUTING.md#pull-requests)
-->

## Description

CI started to fail due to recent changes in GitHub Actions:

> Error: Unable to process command '##[set-env name=pythonLocation;]/opt/hostedtoolcache/Python/3.9.0/x64' successfully.
6
> Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Changing the pinned version from Python from `1.1.1` to `1` should fix it 

<!--
Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Changelog
