### PR TITLE
Fix -- fake_email default max_size is too fragile

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,13 @@ Releases
    :local:
 
 
+master
+~~~~~~
+
+* Updated bulk_update method to use Django's built-in method if available
+* Changed default ``max_size`` for ``fake_email`` to ``40``
+
+
 0.2
 ~~~
 
@@ -31,9 +38,3 @@ Releases
 ~~~
 
 * Initial release
-
-
-master
-~~~~~~
-
-* Updated bulk_update method to use Django's built-in method if available

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ master
 
 * Updated bulk_update method to use Django's built-in method if available
 * Changed default ``max_size`` for ``fake_email`` to ``40``
+* Fixed error in ``fake_text`` when ``max_size`` is too short
 
 
 0.2

--- a/anon/utils.py
+++ b/anon/utils.py
@@ -328,7 +328,7 @@ def fake_username(max_size=10, separator=""):
     return fake_text(max_size, separator=separator) + random_number
 
 
-def fake_email(max_size=25, suffix="@example.com"):
+def fake_email(max_size=40, suffix="@example.com"):
     """ Returns fake email address
 
     :max_size: Maximum number of chars

--- a/anon/utils.py
+++ b/anon/utils.py
@@ -204,8 +204,8 @@ def _cycle_over_sample_range(start, end, sample_size):
     return itertools.cycle(random.sample(xrange(start, end), sample_size))
 
 
-# Holds the average size of word sample
-_avg_word_size = sum(map(len, _WORD_LIST)) / len(_WORD_LIST)
+# Holds the maximum size of word sample
+_max_word_size = max(len(s) for s in _WORD_LIST)
 
 # Holds a generator that each iteration returns a different word
 _word_generator = itertools.cycle(_WORD_LIST)
@@ -266,12 +266,15 @@ def fake_text(max_size=255, max_diff_allowed=5, separator=" "):
     if max_diff_allowed < 1:
         raise ValueError("max_diff_allowed must be > 0")
 
-    num_words = int(max_size / _avg_word_size)
+    num_words = max(1, int(max_size / _max_word_size))
     words = itertools.islice(_word_generator, num_words)
 
     text = separator.join(words)
-    while len(text) > max_size:
-        text = text[: text.rindex(separator)]
+    try:
+        while len(text) > max_size:
+            text = text[: text.rindex(separator)]
+    except ValueError:
+        text = text[:max_size]
 
     return text
 


### PR DESCRIPTION
<!--
Note: Before submitting this pull request, please review our [contributing guidelines](https://github.com/Tesorio/django-anon/blob/master/CONTRIBUTING.md#pull-requests)
-->

## Description

Many times we call `anon.fake_email()` will result in an error:

```
>>> anon.fake_email()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/caio/Projects/Tesorio/django-anon/anon/utils.py", line 353, in fake_email
    return fake_username(max_size, separator=".") + suffix
  File "/Users/caio/Projects/Tesorio/django-anon/anon/utils.py", line 328, in fake_username
    return fake_text(max_size, separator=separator) + random_number
  File "/Users/caio/Projects/Tesorio/django-anon/anon/utils.py", line 274, in fake_text
    text = text[: text.rindex(separator)]
ValueError: substring not found
```

This happens because of two problems:

1. The `fake_text` function does not work well with short strings (< 14 chars). This is the length of the biggest word in the wordlist (see below), and it may cause `fake_text` to raise the exception above.

https://github.com/Tesorio/django-anon/blob/7a02db68f22a8770d08f41692aba1c06b42560fb/anon/utils.py#L6-L10

2. The current defaults for `fake_email` are `fake_email(max_size=25, suffix="@example.com")`, which means there will be only `12 chars` left to generate the first part of the address, as shown below:

| aaaabbbbcccc | @example.com | total
| -- | -- | -- |
| 12 chars | 13 chars | 25 chars |

The first part (`aaaabbbbcccc`) is generated by `fake_text`, as explained before, don't like short strings

## Solution

This PR addresses:

1. Makes `fake_text` handle short strings
2. Increases default `max_size` in `fake_email` to `40`, which is `len("@example.com") + (_max_word_size * 2)`

## Todos

- [ ] Tests
- [ ] Documentation
- [x] Changelog
