### PR TITLE
Bump to 0.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,12 @@ Releases
 master
 ~~~~~~
 
+* ...
+
+
+0.3
+~~~
+
 * Updated bulk_update method to use Django's built-in method if available
 * Changed default ``max_size`` for ``fake_email`` to ``40``
 * Fixed error in ``fake_text`` when ``max_size`` is too short

--- a/anon/__init__.py
+++ b/anon/__init__.py
@@ -2,7 +2,7 @@
 import sys
 
 
-__version__ = "0.2"
+__version__ = "0.3"
 
 try:
     from .base import BaseAnonymizer, lazy_attribute  # noqa: F401


### PR DESCRIPTION
Bump version to 0.3

Process is described here: https://django-anon.readthedocs.io/en/latest/contributing.html#releasing-a-new-version