### PR TITLE
Fixes #63 -- Calling bulk_update w/ incorrect args

### DIFF
--- a/anon/base.py
+++ b/anon/base.py
@@ -88,12 +88,9 @@ class BaseAnonymizer(object):
 
             bulk_update(
                 objs,
+                update_fields,
                 self.get_manager(),
-                **dict(
-                    update_fields=update_fields,
-                    batch_size=update_batch_size,
-                    **bulk_update_kwargs
-                )
+                **dict(batch_size=update_batch_size, **bulk_update_kwargs)
             )
 
         if current_batch == 0:

--- a/anon/compat.py
+++ b/anon/compat.py
@@ -2,7 +2,7 @@
 from django_bulk_update.helper import bulk_update as ext_bulk_update
 
 
-def bulk_update(objects, manager, **bulk_update_kwargs):
+def bulk_update(objects, fields, manager, **bulk_update_kwargs):
     """Updates the list of objects using django queryset's
     inbuilt ``.bulk_update()`` method if present, else
     django_bulk_update's ``bulk_update()`` will be used
@@ -16,6 +16,6 @@ def bulk_update(objects, manager, **bulk_update_kwargs):
     :rtype: None
     """
     try:
-        manager.bulk_update(objects, **bulk_update_kwargs)
+        manager.bulk_update(objects, fields, **bulk_update_kwargs)
     except AttributeError:
-        ext_bulk_update(objects, **bulk_update_kwargs)
+        ext_bulk_update(objects, update_fields=fields, **bulk_update_kwargs)

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -1,6 +1,0 @@
-try:
-    # stdlib
-    from unittest import mock  # noqa: F401
-except ImportError:
-    # deps
-    import mock  # noqa: F401

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,0 +1,30 @@
+# deps
+from django.db import models
+
+
+class PersonAnotherQuerySet(models.QuerySet):
+    pass
+
+
+class Person(models.Model):
+    first_name = models.CharField(max_length=255)
+    last_name = models.CharField(max_length=255)
+
+    line1 = models.CharField(max_length=255)
+    line2 = models.CharField(max_length=255)
+    line3 = models.CharField(max_length=255)
+
+    raw_data = models.TextField()
+
+    another_manager = models.Manager.from_queryset(PersonAnotherQuerySet)
+
+
+def person_factory(**kwargs):
+    kwargs.setdefault("first_name", "A")
+    kwargs.setdefault("last_name", "B")
+    kwargs.setdefault("line1", "X")
+    kwargs.setdefault("line2", "Y")
+    kwargs.setdefault("line3", "Z")
+    kwargs.setdefault("raw_data", '{"access_token": "XYZ"}')
+
+    return Person.objects.create(**kwargs)


### PR DESCRIPTION
<!--
Note: Before submitting this pull request, please review our [contributing guidelines](https://github.com/Tesorio/django-anon/blob/master/CONTRIBUTING.md#pull-requests)
-->

## Description

Fixes https://github.com/Tesorio/django-anon/issues/63

The `compat.bulk_update` is incorrectly passing arguments in newer versions of Django (Django > 2.2)

This PR:

* Refactor tests to not use mocks are they shown to be inefficient to detect these kinds of bugs
* Fix the underlying issue

## Todos

- [x] Tests
- [ ] Documentation
- [x] Changelog
