### PR TITLE
Fix for issue #66: anon.utils.fake_username may enter an infinite loop during short username generation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Releases
 master
 ~~~~~~
 
-* Add regression test and apply fix for fake_username infinite loop condition
+* Fixed an infinite loop condition in ``fake_username`` when using the default empty separator
 
 
 0.3.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Releases
 master
 ~~~~~~
 
-* Add regression test for fake_username infinite loop condition
+* Add regression test and apply fix for fake_username infinite loop condition
 
 
 0.3.1

--- a/anon/utils.py
+++ b/anon/utils.py
@@ -205,10 +205,8 @@ def _cycle_over_sample_range(start, end, sample_size):
 
 
 def _trim_text(text, separator, max_size):
-    try:
-        return text[: text.rindex(separator)]
-    except ValueError:
-        return text[:max_size]
+    limit = min(text.rindex(separator), max_size)
+    return text[:limit]
 
 
 # Holds the maximum size of word sample

--- a/anon/utils.py
+++ b/anon/utils.py
@@ -275,8 +275,11 @@ def fake_text(max_size=255, max_diff_allowed=5, separator=" "):
     words = itertools.islice(_word_generator, num_words)
 
     text = separator.join(words)
-    if len(text) > max_size:
-        text = _trim_text(text, separator, max_size)
+    try:
+        if len(text) > max_size:
+            text = _trim_text(text, separator, max_size)
+    except ValueError:
+        text = text[:max_size]
 
     return text
 

--- a/anon/utils.py
+++ b/anon/utils.py
@@ -275,7 +275,7 @@ def fake_text(max_size=255, max_diff_allowed=5, separator=" "):
     words = itertools.islice(_word_generator, num_words)
 
     text = separator.join(words)
-    while len(text) > max_size:
+    if len(text) > max_size:
         text = _trim_text(text, separator, max_size)
 
     return text

--- a/anon/utils.py
+++ b/anon/utils.py
@@ -204,6 +204,13 @@ def _cycle_over_sample_range(start, end, sample_size):
     return itertools.cycle(random.sample(xrange(start, end), sample_size))
 
 
+def _trim_text(text, separator, max_size):
+    try:
+        return text[: text.rindex(separator)]
+    except ValueError:
+        return text[:max_size]
+
+
 # Holds the maximum size of word sample
 _max_word_size = max(len(s) for s in _WORD_LIST)
 
@@ -270,11 +277,8 @@ def fake_text(max_size=255, max_diff_allowed=5, separator=" "):
     words = itertools.islice(_word_generator, num_words)
 
     text = separator.join(words)
-    try:
-        while len(text) > max_size:
-            text = text[: text.rindex(separator)]
-    except ValueError:
-        text = text[:max_size]
+    while len(text) > max_size:
+        text = _trim_text(text, separator, max_size)
 
     return text
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,8 +46,8 @@ class UtilsTestCase(TestCase):
 
     def test_trim_text_empty_separator(self):
         text = utils._trim_text(text="example", separator="", max_size=5)
-        self.assertTrue(len(text) <= 5)
+        self.assertLessEqual(len(text), 5)
 
     def test_fake_text_short_length_trimming(self):
         text = utils.fake_text(4)
-        self.assertTrue(len(text) <= 4)
+        self.assertLessEqual(len(text), 4)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,3 +47,7 @@ class UtilsTestCase(TestCase):
     def test_trim_text_empty_separator(self):
         text = utils._trim_text(text="example", separator="", max_size=5)
         self.assertTrue(len(text) <= 5)
+
+    def test_fake_text_short_length_trimming(self):
+        text = utils.fake_text(4)
+        self.assertTrue(len(text) <= 4)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,3 +43,7 @@ class UtilsTestCase(TestCase):
     def test_fake_phone_number(self):
         text = utils.fake_phone_number(format="(99) 9999-9999")
         self.assertTrue(bool(re.match(r"^\(\d{2}\) \d{4}-\d{4}$", text)))
+
+    def test_trim_text_empty_separator(self):
+        text = utils._trim_text(text="example", separator="", max_size=5)
+        self.assertTrue(len(text) <= 5)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,5 @@
 # stdlib
-from mock import patch
 import re
-from signal import SIGALRM, alarm, signal
 
 # deps
 from django.test import TestCase
@@ -31,23 +29,6 @@ class UtilsTestCase(TestCase):
         text = utils.fake_username(45, separator="_")
         self.assertIn("_", text)
         self.assertLessEqual(len(text), 45)
-
-    @patch("anon.utils._word_generator", ["placeholder"])
-    def test_fake_username_duration(self):
-        method = utils.fake_username
-        timeout_seconds = 1
-
-        def timeout_handler(signum, frame):
-            raise RuntimeError(
-                "{} method call exceeded {} second timeout".format(
-                    method.__name__, timeout_seconds
-                )
-            )
-
-        signal(SIGALRM, timeout_handler)
-        alarm(timeout_seconds)
-
-        method(max_size=10)
 
     def test_fake_email(self):
         text = utils.fake_email(20)


### PR DESCRIPTION
## Description
`anon.utils.fake_username` [calls `anon.utils.fake_text`](https://github.com/Tesorio/django-anon/blob/6e4f0b5862d66e51689a4bf697eb106efc15c8d8/anon/utils.py#L331) to generate a username prefix with a limited maximum size.   Importantly, this call uses an empty string as a separator (by default).

For any input string `x`, `x.rindex("")` returns the length of the string `x`.

That means that when we reach the loop at https://github.com/Tesorio/django-anon/blob/6e4f0b5862d66e51689a4bf697eb106efc15c8d8/anon/utils.py#L274-L275, the size of `text` will never be reduced (the slice has no lower bound, and the upper bound is the original string length).

If `text` was initially longer than `max_size`, we get stuck in an infinite loop.

Resolves #66.

## Todos

- [x] Tests
- [x] Documentation
- [x] Changelog