### PR TITLE
Fixes #71 -- Avoid `ValueError` if no fields are given

### DIFF
--- a/anon/base.py
+++ b/anon/base.py
@@ -56,6 +56,7 @@ class BaseAnonymizer(object):
 
         queryset = self.get_queryset()
         update_fields = list(self._declarations.keys())
+
         update_batch_size = bulk_update_kwargs.pop(
             "batch_size", self._meta.update_batch_size
         )
@@ -86,12 +87,19 @@ class BaseAnonymizer(object):
                 self.patch_object(obj)
                 objs.append(obj)
 
-            bulk_update(
-                objs,
-                update_fields,
-                self.get_manager(),
-                **dict(batch_size=update_batch_size, **bulk_update_kwargs)
-            )
+            if update_fields:
+                bulk_update(
+                    objs,
+                    update_fields,
+                    self.get_manager(),
+                    **dict(batch_size=update_batch_size, **bulk_update_kwargs)
+                )
+            else:
+                logger.info(
+                    "Skiping bulk update for {}... No fields to update".format(
+                        model_name
+                    )
+                )
 
         if current_batch == 0:
             logger.info("{} has no records".format(model_name))

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -81,6 +81,23 @@ class BaseTestCase(TestCase):
         obj.refresh_from_db()
         self.assertEqual(obj.first_name, "xyz")
 
+    def test_run_without_fields(self):
+        class Anon(BaseAnonymizer):
+            def clean(self, obj):
+                obj.first_name = "xyz"
+                obj.save()
+
+            class Meta:
+                model = models.Person
+
+        obj = models.person_factory()
+
+        anonymizer = Anon()
+        anonymizer.run()
+
+        obj.refresh_from_db()
+        self.assertEqual(obj.first_name, "xyz")
+
     def test_lazy_attribute(self):
         fake_first_name = anon.lazy_attribute(lambda o: o.last_name)
 


### PR DESCRIPTION
<!--
Note: Before submitting this pull request, please review our [contributing guidelines](https://github.com/Tesorio/django-anon/blob/master/CONTRIBUTING.md#pull-requests)
-->

## Description

If no fields are given skip the `bulk_update` to avoid:
```
ValueError: Field names must be given to bulk_update()
```

> Issue: https://github.com/Tesorio/django-anon/issues/71

## Todos

- [x] Tests
- [ ] Documentation
- [ ] Changelog
