### PR TITLE
Drops support for Python 2, Django 1.11, and 2.2, and adds support for Django 4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ Supported versions
 ------------------
 
 * Python (3.7+)
-* Django (2.2, 3.0)
+* Django (3.0, 4)
 
 
 License

--- a/README.rst
+++ b/README.rst
@@ -97,8 +97,8 @@ Installation
 Supported versions
 ------------------
 
-* Python (2.7, 3.7)
-* Django (1.11, 2.2, 3.0)
+* Python (3.7+)
+* Django (2.2, 3.0)
 
 
 License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py27']
+target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
 exclude = '''
 /(
     \.git
@@ -18,7 +18,7 @@ import_heading_firstparty = 'local'
 lines_after_imports = 2
 atomic = true
 combine_star = true
-skip = ['.git', '.venv2', '.venv3']
+skip = ['.git', '.venv3']
 # These settings makes isort compatible with Black:
 # https://github.com/psf/black#how-black-wraps-lines
 multi_line_output = 3

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -3,3 +3,5 @@ INSTALLED_APPS = ["tests"]
 SECRET_KEY = "j^owl8=_)2do0don9sk@5k7obl!vxm!_404wf%yvk9rp3@a83#"
 
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
+
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,8 @@
 [tox]
-envlist = py27-django{111}, py3-django{2,3}
+envlist = py3-django{2,3}
 
 [testenv]
 deps =
-    py27: mock
-    django111: Django>=1.11,<2
-    django2: Django>=2,<3
     django3: Django>=3,<4
     -r tests/requirements.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
-envlist = py3-django{2,3}
+envlist = py3-django{3,4}
 
 [testenv]
 deps =
     django3: Django>=3,<4
+    django4: Django>=4,<5
     -r tests/requirements.txt
 
-commands = ./runtests.py
+commands = python runtests.py
 
 setenv =
     PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION

## Description

closes #77 

This PR drops support for Python 2, Django 1.11, and 2.2, and adds support for Django 4.

- Tox for some reason wasn't running `./runtests.py`, I had to add `python` instead of running the executable
- DEFAULT_AUTO_FIELD is now good to have in settings

## Todos

- [ ] Tests
- [x] Documentation
- [ ] Changelog
