### PR TITLE
Drop support for Python 2, Django 1.11 and 2.2. Add support for Python 3.7+ and Django 3.0+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,18 +20,21 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - py27-django111
-          - py3-django2
-          - py3-django3
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: ${{ matrix.python-version }}
 
-      - run: pip install tox
-      - run: tox -e ${{ matrix.python-version }}
+      - run: pip install tox tox-gh-actions
+      - run: tox
 
   ############
   # Coverage #
@@ -40,10 +43,10 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v1
-      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v2
 
-      - run: pip install coverage
+      - run: pip install coverage setuptools
 
       - run: python setup.py install
       - run: coverage run runtests.py
@@ -69,7 +72,7 @@ jobs:
       with:
         python-version: "3.7"
 
-    - run: python -m pip install black==19.10b0
+    - run: python -m pip install black==19.10b0 click==8.0.4
     - run: black --safe --check --diff .
 
 
@@ -83,7 +86,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: "2.7"
+        python-version: "3.7"
 
     - run: python -m pip install flake8==3.3.0
     - run: flake8 --config=.flake8 .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,108 +1,103 @@
 name: CI
 
 on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
-  schedule:
-    # Run every sunday
-    - cron:  '0 0 * * 0'
+    push:
+        branches: [master]
+    pull_request:
+        branches: [master]
+    schedule:
+        # Run every sunday
+        - cron: "0 0 * * 0"
 
 jobs:
+    ########
+    # Test #
+    ########
 
-  ########
-  # Test #
-  ########
+    test:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                python-version:
+                    - "3.10"
+                    - "3.11"
+                    - "3.12"
+                    - "3.13"
+                    - "3.14"
 
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version:
-          - "3.7"
-          - "3.8"
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "3.12"
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-python@v2
+              with:
+                  python-version: ${{ matrix.python-version }}
 
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
+            - run: pip install tox tox-gh-actions
+            - run: tox
 
-      - run: pip install tox tox-gh-actions
-      - run: tox
+    ############
+    # Coverage #
+    ############
 
-  ############
-  # Coverage #
-  ############
+    coverage:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/setup-python@v2
+            - uses: actions/checkout@v2
 
-  coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-python@v2
-      - uses: actions/checkout@v2
+            - run: pip install coverage setuptools
 
-      - run: pip install coverage setuptools
+            - run: python setup.py install
+            - run: coverage run runtests.py
+            - run: coverage xml
 
-      - run: python setup.py install
-      - run: coverage run runtests.py
-      - run: coverage xml
+            - name: Coverage monitor
+              uses: 5monkeys/cobertura-action@master
+              with:
+                  repo_token: ${{ secrets.GITHUB_TOKEN }}
+                  path: coverage.xml
+                  minimum_coverage: 50
 
-      - name: Coverage monitor
-        uses: 5monkeys/cobertura-action@master
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          path: coverage.xml
-          minimum_coverage: 50
+    #########
+    # Black #
+    #########
 
+    black:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-python@v2
+              with:
+                  python-version: "3.14"
 
-  #########
-  # Black #
-  #########
+            - run: python -m pip install black==19.10b0 click==8.0.4
+            - run: black --safe --check --diff .
 
-  black:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: "3.7"
+    ##########
+    # Flake8 #
+    ##########
 
-    - run: python -m pip install black==19.10b0 click==8.0.4
-    - run: black --safe --check --diff .
+    flake8:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-python@v2
+              with:
+                  python-version: "3.14"
 
+            - run: python -m pip install flake8==3.3.0
+            - run: flake8 --config=.flake8 .
 
-  ##########
-  # Flake8 #
-  ##########
+    ##########
+    # isort #
+    ##########
 
-  flake8:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: "3.7"
+    isort:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-python@v2
+              with:
+                  python-version: "3.14"
 
-    - run: python -m pip install flake8==3.3.0
-    - run: flake8 --config=.flake8 .
-
-
-  ##########
-  # isort #
-  ##########
-
-  isort:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: "3.7"
-
-    - run: python -m pip install isort[pyproject]==4.3.21
-    - run: isort -rc --check-only .
+            - run: python -m pip install isort[pyproject]==4.3.21
+            - run: isort -rc --check-only .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
               with:
                   python-version: "3.13"
 
-            - run: python -m pip install black==19.10b0 click==8.0.4
+            - run: python -m pip install black==26.1.0 click==8.0.4
             - run: black --safe --check --diff .
 
     ##########
@@ -84,7 +84,7 @@ jobs:
               with:
                   python-version: "3.13"
 
-            - run: python -m pip install flake8==3.3.0
+            - run: python -m pip install flake8==7.3.0
             - run: flake8 --config=.flake8 .
 
     ##########
@@ -99,5 +99,5 @@ jobs:
               with:
                   python-version: "3.13"
 
-            - run: python -m pip install isort[pyproject]==4.3.21
+            - run: python -m pip install isort==8.0.1
             - run: isort -rc --check-only .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-python@v2
               with:
-                  python-version: "3.14"
+                  python-version: "3.13"
 
             - run: python -m pip install black==19.10b0 click==8.0.4
             - run: black --safe --check --diff .
@@ -82,7 +82,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-python@v2
               with:
-                  python-version: "3.14"
+                  python-version: "3.13"
 
             - run: python -m pip install flake8==3.3.0
             - run: flake8 --config=.flake8 .
@@ -97,7 +97,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-python@v2
               with:
-                  python-version: "3.14"
+                  python-version: "3.13"
 
             - run: python -m pip install isort[pyproject]==4.3.21
             - run: isort -rc --check-only .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,51 +1,46 @@
-- repo: git://github.com/pre-commit/pre-commit-hooks
-  sha: v0.9.2
-  hooks:
-    - id: check-added-large-files
-      args: ['--maxkb=500']
-    - id: check-byte-order-marker
-    - id: check-case-conflict
-    - id: check-merge-conflict
-    - id: check-symlinks
-    - id: debug-statements
-      language_version: python2.7
-    - id: detect-private-key
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v0.9.2
+    hooks:
+      - id: check-added-large-files
+        args: ["--maxkb=500"]
+      - id: check-byte-order-marker
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: debug-statements
+      - id: detect-private-key
 
-- repo: https://github.com/psf/black
-  sha: 19.10b0
-  hooks:
-    - id: black
-      language_version: python3
+  - repo: https://github.com/psf/black
+    rev: 26.1.0
+    hooks:
+      - id: black
+        # We run black w/ --fast here but CI runs it with --safe
+        entry: black --fast --check
+        # Anytime the exclude rules below change, we also need to update the
+        # pyproject.toml file to reflect the changes. This is because Black will not
+        # respect this rules when running through pre-commit hook, because the pre-commit
+        # hook passes filenames to black, which causes black to ignore any other
+        # checks/exclusions.
+        #
+        # More info here: https://github.com/psf/black/issues/438
+        exclude: \.git
 
-      # We run black w/ --fast here but CI runs it with --safe
-      entry: black --fast --check
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
 
-      # Anytime the exclude rules below change, we also need to update the
-      # pyproject.toml file to reflect the changes. This is because Black will not
-      # respect this rules when running through pre-commit hook, because the pre-commit
-      # hook passes filenames to black, which causes black to ignore any other
-      # checks/exclusions.
-      #
-      # More info here: https://github.com/psf/black/issues/438
-      exclude: \.git
+  - repo: https://github.com/timothycrosley/isort
+    rev: 8.0.1
+    hooks:
+      - id: isort
+        entry: isort --check-only
+        additional_dependencies: ["toml"]
 
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.8
-  hooks:
-    - id: flake8
-      language_version: python2
-
-- repo: https://github.com/timothycrosley/isort
-  rev: 4.3.21
-  hooks:
-    - id: isort
-      entry: isort --check-only
-      language_version: python3
-      additional_dependencies: ["toml"]
-
-      # Anytime the exclude rules below change, we also need to update the .isort.cfg
-      # file to reflect the changes. This is because isort will not respect this rules
-      # when running through pre-commit hook, because the pre-commit hook passes
-      # filenames to isort, which causes isort to ignore any other checks/exclusions.
-      #
-      exclude: \.git
+        # Anytime the exclude rules below change, we also need to update the .isort.cfg
+        # file to reflect the changes. This is because isort will not respect this rules
+        # when running through pre-commit hook, because the pre-commit hook passes
+        # filenames to isort, which causes isort to ignore any other checks/exclusions.
+        #
+        exclude: \.git

--- a/README.rst
+++ b/README.rst
@@ -97,8 +97,8 @@ Installation
 Supported versions
 ------------------
 
-* Python (2.7, 3.7)
-* Django (1.11, 2.2, 3.0)
+* Python 3.7+
+* Django 3.0+
 
 
 License

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@
         <img src="https://img.shields.io/pypi/v/django-anon.svg?color=blue">
       </a>
     </p>
-    
+
     <p align="center">
       <a href="#installation">
         Install
@@ -93,12 +93,12 @@ Installation
 
    pip install django-anon
 
-   
+
 Supported versions
 ------------------
 
-* Python 3.7+
-* Django 3.0+
+* Python 3.10+
+* Django 4.2+
 
 
 License
@@ -123,7 +123,7 @@ Use ``anon.BaseAnonymizer`` to define your anonymizer classes:
 
    class PersonAnonymizer(anon.BaseAnonymizer):
       email = anon.fake_email
-      
+
       # You can use static values instead of callables
       is_admin = False
 

--- a/anon/__init__.py
+++ b/anon/__init__.py
@@ -1,7 +1,6 @@
 # stdlib
 import sys
 
-
 __version__ = "0.3.2"
 
 try:

--- a/anon/base.py
+++ b/anon/base.py
@@ -8,17 +8,16 @@ from chunkator import chunkator_page
 # local
 from anon.compat import bulk_update
 
-
 logger = getLogger(__name__)
 
 
 class OrderedDeclaration(object):
-    """ Any classes inheriting from this will have an unique global counter
-        associated with it. This counter is used to determine the order in
-        which fields were declarated
+    """Any classes inheriting from this will have an unique global counter
+    associated with it. This counter is used to determine the order in
+    which fields were declarated
 
-        Idea taken from: https://stackoverflow.com/a/4460034/639465
-        Also inspired by https://github.com/FactoryBoy/factory_boy
+    Idea taken from: https://stackoverflow.com/a/4460034/639465
+    Also inspired by https://github.com/FactoryBoy/factory_boy
     """
 
     global_counter = 0
@@ -38,13 +37,13 @@ class LazyAttribute(OrderedDeclaration):
 
 
 def lazy_attribute(lazy_fn):
-    """ Returns LazyAttribute objects, that basically marks functions that
-        should take `obj` as first parameter. This is useful when you need
-        to take in consideration other values of `obj`
+    """Returns LazyAttribute objects, that basically marks functions that
+    should take `obj` as first parameter. This is useful when you need
+    to take in consideration other values of `obj`
 
-        Example:
+    Example:
 
-        >>> full_name = lazy_attribute(o: o.first_name + o.last_name)
+    >>> full_name = lazy_attribute(o: o.first_name + o.last_name)
 
     """
     return LazyAttribute(lazy_fn)
@@ -92,7 +91,7 @@ class BaseAnonymizer(object):
                     objs,
                     update_fields,
                     self.get_manager(),
-                    **dict(batch_size=update_batch_size, **bulk_update_kwargs)
+                    **dict(batch_size=update_batch_size, **bulk_update_kwargs),
                 )
             else:
                 logger.info(
@@ -123,14 +122,13 @@ class BaseAnonymizer(object):
     _manager = property(get_manager)
 
     def get_queryset(self):
-        """ Override this if you want to delimit the objects that should be
-            affected by anonymization
+        """Override this if you want to delimit the objects that should be
+        affected by anonymization
         """
         return self.get_manager().all()
 
     def patch_object(self, obj):
-        """ Update object attributes with fake data provided by replacers
-        """
+        """Update object attributes with fake data provided by replacers"""
         # using obj.__dict__ instead of getattr for performance reasons
         # see https://stackoverflow.com/a/9791053/639465
         fields = [field for field in self._declarations if obj.__dict__[field]]
@@ -150,17 +148,17 @@ class BaseAnonymizer(object):
         self.clean(obj)
 
     def clean(self, obj):
-        """ Use this function if you need to update additional data that may
-            rely on multiple fields, or if you need to update multiple fields
-            at once
+        """Use this function if you need to update additional data that may
+        rely on multiple fields, or if you need to update multiple fields
+        at once
         """
         pass
 
     def get_declarations(self):
-        """ Returns ordered declarations. Any non-ordered declarations, for
-            example any types that does not inherit from OrderedDeclaration
-            will come first, as they are considered "raw" values and should
-            not be affected by the order of other non-ordered declarations
+        """Returns ordered declarations. Any non-ordered declarations, for
+        example any types that does not inherit from OrderedDeclaration
+        will come first, as they are considered "raw" values and should
+        not be affected by the order of other non-ordered declarations
         """
 
         def _sort_declaration(declaration):
@@ -177,8 +175,8 @@ class BaseAnonymizer(object):
         return OrderedDict(sorted_declarations)
 
     def _get_class_attributes(self):
-        """ Return list of class attributes, which also includes methods and
-            subclasses, ignoring any magic methods and reserved attributes
+        """Return list of class attributes, which also includes methods and
+        subclasses, ignoring any magic methods and reserved attributes
         """
         reserved_names = list(BaseAnonymizer.__dict__.keys()) + ["Meta"]
 

--- a/anon/utils.py
+++ b/anon/utils.py
@@ -2,7 +2,6 @@
 import itertools
 import random
 
-
 _WORD_LIST = [
     "a",
     "ab",
@@ -235,7 +234,7 @@ _signed_int_generator = _cycle_over_sample_range(-2147483648, 2147483647, 100000
 
 
 def fake_word(min_size=_min_word_size, max_size=20):
-    """ Return fake word
+    """Return fake word
 
     :min_size: Minimum number of chars
     :max_size: Maximum number of chars
@@ -256,7 +255,7 @@ def fake_word(min_size=_min_word_size, max_size=20):
 
 
 def fake_text(max_size=255, max_diff_allowed=5, separator=" "):
-    """ Return fake text
+    """Return fake text
 
     :max_size: Maximum number of chars
     :max_diff_allowed: Maximum difference (fidelity) allowed, in chars number
@@ -285,7 +284,7 @@ def fake_text(max_size=255, max_diff_allowed=5, separator=" "):
 
 
 def fake_small_text(max_size=50):
-    """ Preset for fake_text.
+    """Preset for fake_text.
 
     :max_size: Maximum number of chars
 
@@ -299,7 +298,7 @@ def fake_small_text(max_size=50):
 
 
 def fake_name(max_size=15):
-    """ Preset for fake_text. Also returns capitalized words.
+    """Preset for fake_text. Also returns capitalized words.
 
     :max_size: Maximum number of chars
 
@@ -313,7 +312,7 @@ def fake_name(max_size=15):
 
 
 def fake_username(max_size=10, separator=""):
-    """ Returns fake username
+    """Returns fake username
 
     :max_size: Maximum number of chars
     :separator: Word separator
@@ -337,7 +336,7 @@ def fake_username(max_size=10, separator=""):
 
 
 def fake_email(max_size=40, suffix="@example.com"):
-    """ Returns fake email address
+    """Returns fake email address
 
     :max_size: Maximum number of chars
     :suffix: Suffix to add to email addresses (including @)
@@ -362,7 +361,7 @@ def fake_email(max_size=40, suffix="@example.com"):
 
 
 def fake_url(max_size=50, scheme="http://", suffix=".com"):
-    """ Returns fake URL
+    """Returns fake URL
 
     :max_size: Maximum number of chars
     :scheme: URL scheme (http://)
@@ -386,7 +385,7 @@ def fake_url(max_size=50, scheme="http://", suffix=".com"):
 
 
 def fake_phone_number(format="999-999-9999"):
-    """ Returns a fake phone number in the desired format
+    """Returns a fake phone number in the desired format
 
     :format: Format of phone number to generate
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,6 @@
 import os
 import sys
 
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -23,14 +22,14 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(".")))
 
 # -- Project information -----------------------------------------------------
 
-project = u"django-anon"
-copyright = u"2019, Tesorio"
-author = u"Tesorio"
+project = "django-anon"
+copyright = "2019, Tesorio"
+author = "Tesorio"
 
 # The short X.Y version
-version = u""
+version = ""
 # The full version, including alpha/beta/rc tags
-release = u""
+release = ""
 
 
 # -- General configuration ---------------------------------------------------
@@ -68,7 +67,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = [u"_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None
@@ -130,7 +129,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "django-anon.tex", u"django-anon Documentation", u"Tesorio", "manual"),
+    (master_doc, "django-anon.tex", "django-anon Documentation", "Tesorio", "manual"),
 ]
 
 
@@ -138,7 +137,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "django-anon", u"django-anon Documentation", [author], 1)]
+man_pages = [(master_doc, "django-anon", "django-anon Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output ----------------------------------------------
@@ -150,7 +149,7 @@ texinfo_documents = [
     (
         master_doc,
         "django-anon",
-        u"django-anon Documentation",
+        "django-anon Documentation",
         author,
         "django-anon",
         "One line description of project.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ target-version = ['py27']
 exclude = '''
 /(
     \.git
-  | \.venv([23])?
+  | \.venv
 )/
 '''
 
@@ -18,7 +18,7 @@ import_heading_firstparty = 'local'
 lines_after_imports = 2
 atomic = true
 combine_star = true
-skip = ['.git', '.venv2', '.venv3']
+skip = ['.git', '.venv']
 # These settings makes isort compatible with Black:
 # https://github.com/psf/black#how-black-wraps-lines
 multi_line_output = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py27']
+target-version = ['py310']
 exclude = '''
 /(
     \.git
@@ -8,21 +8,5 @@ exclude = '''
 '''
 
 [tool.isort]
-known_django = 'django'
-known_first_party = ['anon']
-sections = ['FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']
-default_section = 'THIRDPARTY'
-import_heading_stdlib = 'stdlib'
-import_heading_thirdparty = 'deps'
-import_heading_firstparty = 'local'
-lines_after_imports = 2
-atomic = true
-combine_star = true
 skip = ['.git', '.venv']
-# These settings makes isort compatible with Black:
-# https://github.com/psf/black#how-black-wraps-lines
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = false
-use_parentheses = true
-line_length = 88
+profile = "black"

--- a/runtests.py
+++ b/runtests.py
@@ -6,9 +6,7 @@
 import os
 import sys
 
-# deps
 import django
-
 
 if __name__ == "__main__":
     os.environ["DJANGO_SETTINGS_MODULE"] = "tests.settings"

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import os
 # deps
 from setuptools import Command, find_packages, setup
 
-
 # Dynamically calculate the version based on anon.VERSION
 VERSION = __import__("anon").__version__
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,4 +1,3 @@
-# deps
 from django.db import models
 
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,2 @@
 django-bulk-update
-django-chunkator
+django-chunkator<2

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -3,3 +3,5 @@ INSTALLED_APPS = ["tests"]
 SECRET_KEY = "j^owl8=_)2do0don9sk@5k7obl!vxm!_404wf%yvk9rp3@a83#"
 
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
+
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,3 @@
-# deps
 from django.test import TestCase
 
 # local

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,4 +1,3 @@
-# deps
 from django.test import TestCase
 
 # local

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,6 @@
 # stdlib
 import re
 
-# deps
 from django.test import TestCase
 
 # local

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,26 @@
 [tox]
-envlist = py27-django{111}, py3-django{2,3}
+envlist = 
+    py{37,38,39,310,311,312}-django{3}
+    py{38,39,310,311,312}-django{4}
+    py{310,311,312}-django{5}
+
+[gh-actions]
+python =
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
+    3.12: py312
 
 [testenv]
 deps =
-    py27: mock
-    django111: Django>=1.11,<2
-    django2: Django>=2,<3
     django3: Django>=3,<4
+    django4: Django>=4,<5
+    django5: Django>=5,<6
     -r tests/requirements.txt
 
-commands = ./runtests.py
+commands = python runtests.py
 
 setenv =
     PYTHONDONTWRITEBYTECODE=1

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,22 @@
 [tox]
-envlist = 
-    py{37,38,39,310,311,312}-django{3}
-    py{38,39,310,311,312}-django{4}
-    py{310,311,312}-django{5}
+envlist =
+    py{310,311,312}-django{42}
+    py{310,311,312,313,314}-django{52}
+    py{312,313,314}-django{60}
 
 [gh-actions]
 python =
-    3.7: py37
-    3.8: py38
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
+    3.14: py314
 
 [testenv]
 deps =
-    django3: Django>=3,<4
-    django4: Django>=4,<5
-    django5: Django>=5,<6
+    django42: Django>=4.2.8,<5
+    django52: Django>=5.2.8,<6
+    django60: Django>=6.0,<6.1
     -r tests/requirements.txt
 
 commands = python runtests.py


### PR DESCRIPTION
## Description

Closes #77 

We use `django-anon` in our project, which we are in the process of upgrading through `django` versions 3 -> 4 -> 5.

This package still appears to be compatible with at least Python 3.7+ and Django 3.0+, so I've updated the tests, CI and documentation to confirm and reflect this. Given that [Python 2](https://endoflife.date/python), [Django 1 and Django 2](https://endoflife.date/django) are no longer supported, I've dropped them from the tests, CI and documentation.

See the following for CI testing results: https://github.com/BrightpathProgress/django-anon/actions/runs/7707166404

Its also probably worth updating `isort` / `flake8` / `black`, as well as removing some compatibility related code for Python 2.7, Django 1 and Django 2, but I've omitted that to reduce noise / unnecessary changes.

## Changes
- Drops support / testing for Python 2, Django 1.11 and Django 2.2
- Adds support / testing for Python 3.7+ and Django 3.0+

## Todos

- [x] Tests
- [x] Documentation
- [ ] Changelog
